### PR TITLE
Added some missing options to the usage message when run without args

### DIFF
--- a/telnetlogger.c
+++ b/telnetlogger.c
@@ -702,7 +702,7 @@ main(int argc, char *argv[])
 		case 'h':
 		case '?':
 		case 'H':
-			fprintf(stderr, "usage:\n telnetlogger [-p passwords.txt] [-i ips.txt]\n");
+			fprintf(stderr, "usage:\n telnetlogger [-p passwords.txt] [-i ips.txt] [-c telnetlog.csv] [-l port]\n");
 			exit(1);
 			break;
 		}


### PR DESCRIPTION
Simple adjustment, but I figured rather than file an issue, I'd just submit a diff. 